### PR TITLE
fix: fix token cache key

### DIFF
--- a/logto-sample/config/application.rb
+++ b/logto-sample/config/application.rb
@@ -24,7 +24,10 @@ module LogtoSample
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
     config.session_store(
-      :cookie_store,
+      # We don't use the cookie store since the session data can be large, and
+      # cookies have a size limit of 4KB. Remember to replace it with other stores in
+      # production.
+      :cache_store,
       key: "_logto_sample",
       secure: Rails.env.production?,
       httponly: true,

--- a/logto/lib/logto/core/utils.rb
+++ b/logto/lib/logto/core/utils.rb
@@ -41,6 +41,6 @@ module LogtoUtils
   end
 
   def self.build_access_token_key(resource:, organization_id: nil)
-    "#{organization_id ? "##{organization_id}" : ""}:#{resource || "openid"}"
+    "#{organization_id ? "##{organization_id}" : ""}:#{resource || "default"}"
   end
 end

--- a/logto/spec/core/utils_spec.rb
+++ b/logto/spec/core/utils_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe LogtoUtils do
 
   describe "#build_access_token_key" do
     it "builds a key without resource and organization ID" do
-      expect(LogtoUtils.build_access_token_key(resource: nil)).to eq(":openid")
+      expect(LogtoUtils.build_access_token_key(resource: nil)).to eq(":default")
     end
 
     it "builds a key with resource and organization ID" do
@@ -48,7 +48,7 @@ RSpec.describe LogtoUtils do
     end
 
     it "builds a key without resource and with organization ID" do
-      expect(LogtoUtils.build_access_token_key(resource: nil, organization_id: "organization_id")).to eq("#organization_id:openid")
+      expect(LogtoUtils.build_access_token_key(resource: nil, organization_id: "organization_id")).to eq("#organization_id:default")
     end
   end
 end


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
the client should correctly store the token response according to the resource and organization id requested.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
added unit tests
