### PR TITLE
refactor: use native a tag

### DIFF
--- a/logto-sample/app/views/sample/index.html.erb
+++ b/logto-sample/app/views/sample/index.html.erb
@@ -3,10 +3,11 @@
 <p>Is authenticated: <%= @client.is_authenticated? %></p>
 
 <% if @client.is_authenticated? %>
-  <%= link_to "Sign out", sign_out_path %>
+  <a href="<%= sign_out_path %>">Sign out</a>
+  <p>Welcome, <%= @client.id_token_claims["username"] %></p>
   <p>Userinfo: <%= @client.fetch_user_info %></p>
   <!-- Uncomment the following line to fetch the access token claims for a resource -->
   <!-- <p>Resource access token: <%# @client.access_token_claims(resource: "https://shopping.api/") %></p> -->
 <% else %>
-  <%= link_to "Sign in", sign_in_path %>
+  <a href="<%= sign_in_path %>">Sign in</a>
 <% end %>


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

replace `link_to` with the native `<a>` tag since `link_to` has an aggressive prefetch strategy which performs the request on hover. it is not expected for our purpose.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
local tested, no prefetch
