### PR TITLE
chore: fix high dependabot alert for rack (CVE-2026-22860)

### DIFF
--- a/logto-sample/Gemfile.lock
+++ b/logto-sample/Gemfile.lock
@@ -166,7 +166,7 @@ GEM
     puma (6.4.3)
       nio4r (~> 2.0)
     racc (1.8.1)
-    rack (3.2.3)
+    rack (3.2.5)
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -276,7 +276,6 @@ DEPENDENCIES
   jbuilder
   logto!
   puma (>= 5.0)
-  rack (>= 3.2.2)
   rails (~> 8.0.0, >= 8.0.2)
   redis (>= 4.0.1)
   selenium-webdriver


### PR DESCRIPTION
## Summary
Upgrade `rack` in `logto-sample/Gemfile.lock` from `3.2.3` to `3.2.5` to address the high-severity Dependabot alert:
- GHSA-mxw3-3hh2-x2mh
- CVE-2026-22860

## Testing
Tested locally

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
